### PR TITLE
Update dependencies ing PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,15 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: 3.12.3
+        uses: azure/setup-helm@v4.2.0
 
       - name: Install unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.3.5
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version 0.5.2
 
       - name: helm lint
         run: helm lint helm-chart-sources/*
@@ -23,12 +21,12 @@ jobs:
       - name: helm unittest
         run: helm unittest helm-chart-sources/*
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '>=1.19.0'
 
       - name: Install kubeconform
-        run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.6.3
+        run: go install github.com/yannh/kubeconform/cmd/kubeconform@v0.6.7
 
       - name: kubeconform
         run: ./scripts/kubeconform.sh

--- a/common_docs/EXTRA_EXAMPLES.md
+++ b/common_docs/EXTRA_EXAMPLES.md
@@ -124,12 +124,12 @@ If you specify a `extraVolumeMounts.claimTemplate` attribute (and you have speci
 <dt>readOnly</dt>
 <dd>Whether to mount the volume read-only or read/write – default is read/write. </dd>
 <dt>claimTemplate</dt>
-<dd>If this is set, it decribes the PVC that will be created for each pod. <em>Statefulset deployment only.</em></dd>
+<dd>If this is set, it describes the PVC that will be created for each pod. <em>Statefulset deployment only.</em></dd>
 </dl>
 
 ### Example
 This example mounts two extra directories:
-* An `emptyDir`, mounted on /var/lib/testin
+* An `emptyDir`, mounted on /var/lib/testing
 * An existing PVC, called `test-volume`, mounted on `/var/tmp/test-volume`
 
 ```

--- a/helm-chart-sources/edge/Chart.yaml
+++ b/helm-chart-sources/edge/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: edge
 description: A Helm chart for Kubernetes
 type: application
-version: 4.7.3
-appVersion: 4.7.3
+version: 4.8.0
+appVersion: 4.8.0
 icon: https://criblio.github.io/helm-charts/images/Cribl_Logo_Color_TM.png
 
 #dependencies:

--- a/helm-chart-sources/edge/README.md
+++ b/helm-chart-sources/edge/README.md
@@ -38,7 +38,7 @@ This section covers the most likely values to override. To see the full scope of
 |--------------------------------------------------------------------------------|-------------------|-------------------------------------------------------------------------------------|
 | image.repository                                                               | `cribl/cribl`     | Docker image repository to pull images                                              |
 | image.pullPolicy                                                               | `Always`          | When will the Node pull the image                                                   |
-| image.tag                                                                      | `4.7.3`           | The Version of Cribl to deploy                                                      |
+| image.tag                                                                      | `4.8.0`           | The Version of Cribl to deploy                                                      |
 | imagePullSecrets                                                               | `[]`              | Credentials to pull container images                                                |
 | nameOverride                                                                   |                   | Overrides the chart name                                                            |
 | fullNameOverride                                                               |                   | Overrides the Helm deployment name                                                  |

--- a/helm-chart-sources/edge/values.yaml
+++ b/helm-chart-sources/edge/values.yaml
@@ -4,7 +4,7 @@ image:
   repository: cribl/cribl
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.7.3
+  tag: 4.8.0
 
 imagePullSecrets: []
 nameOverride: ""

--- a/helm-chart-sources/logstream-leader/Chart.yaml
+++ b/helm-chart-sources/logstream-leader/Chart.yaml
@@ -16,9 +16,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.3
+version: 4.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.7.3
+appVersion: 4.8.0

--- a/helm-chart-sources/logstream-leader/README.md
+++ b/helm-chart-sources/logstream-leader/README.md
@@ -11,7 +11,7 @@ If you're migrating from the deprecated `logstream‑master` chart, please see t
 
 # New Capabilities
 
-* Support for the 4.7.3 version of Cribl Stream (default version)
+* Support for the 4.8.0 version of Cribl Stream (default version)
 
 # Deployment
 

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -9,7 +9,7 @@ criblImage:
   repository: cribl/cribl
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.7.3
+  tag: 4.8.0
 
 imagePullSecrets: []
 nameOverride: "leader"

--- a/helm-chart-sources/logstream-leader/values.yaml
+++ b/helm-chart-sources/logstream-leader/values.yaml
@@ -53,7 +53,7 @@ persistence:
   # -- Disable this to use an emptyDir for CRIBL_VOLUME_DIR config storage
   enabled: true
   # -- Unset claimName to use the Helm Release name as the PVC name
-  # This is set for backwards compatability purposes
+  # This is set for backwards compatibility purposes
   claimName: leader-config-claim
   # -- Set storageClassName to use a class other than the default
   # Will prioritize this value above the value defined in config.scName

--- a/helm-chart-sources/logstream-workergroup/Chart.yaml
+++ b/helm-chart-sources/logstream-workergroup/Chart.yaml
@@ -15,9 +15,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.7.3
+version: 4.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 4.7.3
+appVersion: 4.8.0

--- a/helm-chart-sources/logstream-workergroup/README.md
+++ b/helm-chart-sources/logstream-workergroup/README.md
@@ -8,7 +8,7 @@ This chart deploys a Cribl Stream worker group.
 Versions starting with 3.4.0 include a change to the syntax for RBAC values. Before you upgrade the chart from pre-3.4.0 versions, please see the [table below](#values) for current options for the `rbac.apiGroups`, `rbac.verbs`, and `rbac.resources` values.
 
 # New Capabilities
-* Support for the 4.7.3 version of Cribl Stream (default version)
+* Support for the 4.8.0 version of Cribl Stream (default version)
 
 # Deployment
 

--- a/helm-chart-sources/logstream-workergroup/values.yaml
+++ b/helm-chart-sources/logstream-workergroup/values.yaml
@@ -24,7 +24,7 @@ criblImage:
   repository: cribl/cribl
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: 4.7.3
+  tag: 4.8.0
 
 imagePullSecrets: []
 nameOverride: ""

--- a/index.yaml
+++ b/index.yaml
@@ -3,9 +3,9 @@ entries:
   appscope:
   - apiVersion: v2
     appVersion: 1.3.4
-    created: "2024-07-19T17:30:36.50319142Z"
+    created: "2024-08-14T12:50:46.267123311Z"
     description: Cribl AppScope Helm Chart for Kubernetes.
-    digest: fa2289790ae2ca425fad722d35758301dc63c0be1067ed6b2015158859f5ed48
+    digest: 02c5abdbb1d5c5337214d760a2444315aaa6bf3748c73516ff5c1ae4d692a87c
     home: https://appscope.dev/
     icon: https://criblio.github.io/helm-charts/images/Cribl_Logo_Color_TM.png
     name: appscope
@@ -13,7 +13,7 @@ entries:
     - https://github.com/criblio/appscope
     type: application
     urls:
-    - https://github.com/criblio/helm-charts/releases/download/v4.7.3/appscope-1.3.4.tgz
+    - https://github.com/criblio/helm-charts/releases/download/v4.8.0/appscope-1.3.4.tgz
     version: 1.3.4
   - apiVersion: v2
     appVersion: 1.3.3
@@ -46,9 +46,9 @@ entries:
   common:
   - apiVersion: v2
     appVersion: 1.0.0
-    created: "2024-07-19T17:30:36.503409307Z"
+    created: "2024-08-14T12:50:46.267652804Z"
     description: Common templates for Cribl Helm Charts
-    digest: 20d89dc75ab4011f0e5c3879b7d9e8f546484b368aa23c1dacc074633a275288
+    digest: d48069761de396e6590a549a34a1a36c54979d6a6c6a0973373a43d30adcc41f
     maintainers:
     - email: support@cribl.io
       name: Cribl, Inc.
@@ -56,9 +56,20 @@ entries:
     name: common
     type: library
     urls:
-    - https://github.com/criblio/helm-charts/releases/download/v4.7.3/common-1.0.0.tgz
+    - https://github.com/criblio/helm-charts/releases/download/v4.8.0/common-1.0.0.tgz
     version: 1.0.0
   edge:
+  - apiVersion: v2
+    appVersion: 4.8.0
+    created: "2024-08-14T12:50:46.268645641Z"
+    description: A Helm chart for Kubernetes
+    digest: 2aa098b98c02f38a255b1a91d22008460a05dcf27bd7f5657a5557b7301e66e9
+    icon: https://criblio.github.io/helm-charts/images/Cribl_Logo_Color_TM.png
+    name: edge
+    type: application
+    urls:
+    - https://github.com/criblio/helm-charts/releases/download/v4.8.0/edge-4.8.0.tgz
+    version: 4.8.0
   - apiVersion: v2
     appVersion: 4.7.3
     created: "2024-07-19T17:30:36.504381012Z"
@@ -368,6 +379,17 @@ entries:
     - https://github.com/criblio/helm-charts/releases/download/v4.0.0/edge-4.0.0.tgz
     version: 4.0.0
   logstream-leader:
+  - apiVersion: v2
+    appVersion: 4.8.0
+    created: "2024-08-14T12:50:46.269684634Z"
+    description: Deploys a Cribl Stream Leader in K8s.
+    digest: 5f171394915cf50e2a20ad4e040350dc8879124812c74d219ce257aaef591a94
+    icon: https://criblio.github.io/helm-charts/images/Cribl_Logo_Color_TM.png
+    name: logstream-leader
+    type: application
+    urls:
+    - https://github.com/criblio/helm-charts/releases/download/v4.8.0/logstream-leader-4.8.0.tgz
+    version: 4.8.0
   - apiVersion: v2
     appVersion: 4.7.3
     created: "2024-07-19T17:30:36.505376753Z"
@@ -888,6 +910,17 @@ entries:
     version: 2.4.5
   logstream-workergroup:
   - apiVersion: v2
+    appVersion: 4.8.0
+    created: "2024-08-14T12:50:46.270694402Z"
+    description: Deployment of Cribl Stream Worker Group on K8s
+    digest: 13eb6fc8310e690a000939363c8f4f626af42ff6e329bdac2a4145fae71e314e
+    icon: https://criblio.github.io/helm-charts/images/Cribl_Logo_Color_TM.png
+    name: logstream-workergroup
+    type: application
+    urls:
+    - https://github.com/criblio/helm-charts/releases/download/v4.8.0/logstream-workergroup-4.8.0.tgz
+    version: 4.8.0
+  - apiVersion: v2
     appVersion: 4.7.3
     created: "2024-07-19T17:30:36.506400665Z"
     description: Deployment of Cribl Stream Worker Group on K8s
@@ -1385,14 +1418,14 @@ entries:
   pod-killer:
   - apiVersion: v2
     appVersion: 1.0.0
-    created: "2024-07-19T17:30:36.506731423Z"
+    created: "2024-08-14T12:50:46.271009782Z"
     description: A Simple Cron Job that deletes pods based on pod name on a schedule
       defined in annotations.
-    digest: 6f382de80e5b5e16c19ff59a15084e2e59e696e775acb5cad3abaa2974ab7f7e
+    digest: 5331e478ee08c63d422b88332f54b9c46bf05e703a3897793746485b1e58777d
     icon: https://criblio.github.io/helm-charts/images/Cribl_Logo_Color_TM.png
     name: pod-killer
     type: application
     urls:
-    - https://github.com/criblio/helm-charts/releases/download/v4.7.3/pod-killer-1.0.0.tgz
+    - https://github.com/criblio/helm-charts/releases/download/v4.8.0/pod-killer-1.0.0.tgz
     version: 1.0.0
-generated: "2024-07-19T17:30:36.502467116Z"
+generated: "2024-08-14T12:50:46.266047448Z"


### PR DESCRIPTION
- Get rid of the following warning The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/checkout@v3, azure/setup-helm@v3, actions/setup-go@v4. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
- Bump the helm-unittest to 0.5.2
- Bump the kubeconfrom to 0.6.7